### PR TITLE
Add interactive Streamlit dashboard for certification data

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Interactive dashboard for certification data.
 ## Streamlit Dashboard
 
 ```bash
+pip install -r requirements.txt
 streamlit run dashboard.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# training-dashboard
+# Training Dashboard
+
+Interactive dashboard for certification data.
+
+## Web Version
+Open `index.html` in a web browser to explore filters and charts.
+
+## Python Prototype
+The original Streamlit prototype remains in `dashboard.py`.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,18 @@
 
 Interactive dashboard for certification data.
 
-## Web Version
-Open `index.html` in a web browser to explore filters and charts.
+## Streamlit Dashboard
 
-## Python Prototype
-The original Streamlit prototype remains in `dashboard.py`.
+```bash
+streamlit run dashboard.py
+```
+
+- Loads a `certifications.xlsx` file placed next to the script or uploaded via the sidebar (up to 75,000 rows).
+- Provides filters for year, gender, region, certificate type, and text search.
+- Charts update automatically and each includes a PNG download button.
+
+If no Excel file is supplied, a random sample of 500 records is generated for demonstration.
+
+## Static Web Version
+
+Open `index.html` in a web browser to explore filters and charts without Python.

--- a/dashboard.py
+++ b/dashboard.py
@@ -10,34 +10,63 @@ from io import BytesIO
 
 st.set_page_config(page_title="자격증 대시보드", layout="wide", page_icon="📊")
 
-# ----- 스타일 및 헤더 구성 -----
+# ----- 글로벌 스타일 및 헤더 구성 -----
 st.markdown(
     """
     <style>
-    .top-nav {
-        background: linear-gradient(90deg, #0d6efd, #2a52be);
-        color: white;
-        padding: 1rem 2rem;
-        border-radius: 8px;
-        font-size: 1.3rem;
-        font-weight: 700;
-        margin-bottom: 1rem;
+    @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
+    html, body, [class*="css"] {
+        font-family: 'Noto Sans KR', sans-serif;
+        background:#f8fafc;
+        color:#64748b;
     }
-    .metric-card {
-        padding: 1.2rem;
-        border-radius: 0.5rem;
-        box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-        text-align: center;
-        color: white;
+    .stApp {background:#f8fafc;}
+    .header {
+        position: sticky; top:0; z-index:100;
+        display:flex; justify-content:space-between; align-items:center;
+        background:#ffffff; padding:12px 24px; border-bottom:1px solid #e2e8f0;
     }
-    .metric-purple {background:#6f42c1;}
-    .metric-blue {background:#0d6efd;}
-    .metric-indigo {background:#6610f2;}
-    .metric-card h3{font-size:1rem;font-weight:600;margin:0 0 .5rem 0;}
-    .metric-card p{font-size:2rem;font-weight:700;margin:0;}
-    div[data-testid="stSidebar"] .stButton>button{width:100%;}
+    .header-left .title{font-size:20px;font-weight:700;color:#1e293b;}
+    .header-left .breadcrumb{font-size:14px;color:#64748b;}
+    .header-buttons button{
+        background:#2563eb; color:#fff; border:none; border-radius:8px;
+        padding:8px; margin-left:8px; cursor:pointer;
+    }
+    .header-buttons button:hover{background:#3b82f6;}
+    div[data-testid="stSidebar"]{background:#ffffff;}
+    .metric-card{
+        border-radius:12px;
+        box-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1),0 2px 4px -2px rgb(0 0 0 / 0.1);
+        padding:24px; margin-bottom:16px; background:#ffffff; color:#1e293b;
+        transition:box-shadow .2s ease;
+    }
+    .metric-card.primary{background:#2563eb;color:#ffffff;}
+    .metric-card h3{margin:0 0 8px 0; font-size:1rem; font-weight:600; color:#1e293b;}
+    .metric-card.primary h3{color:#ffffff;}
+    .metric-card p{margin:0; font-size:1.5rem; font-weight:700;}
+    .metric-card.primary p{color:#ffffff;}
+    .metric-card:hover{
+        box-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1),0 4px 6px -4px rgb(0 0 0 / 0.1);
+    }
+    .stButton>button{background:#2563eb;color:#fff;border:none;border-radius:8px;padding:10px 16px;}
+    .stButton>button:hover{background:#3b82f6;}
+    .stButton.secondary>button{background:#e2e8f0;color:#475569;}
+    .stDownloadButton>button{background:#2563eb;color:#fff;border:none;border-radius:8px;padding:10px 16px;}
+    .stDownloadButton>button:hover{background:#3b82f6;}
+    @media (max-width:480px){
+        .metric-container .metric-card{width:100%;}
+    }
     </style>
-    <div class="top-nav">자격증 취득자 분석 대시보드</div>
+    <div class="header">
+        <div class="header-left">
+            <div class="title">자격증 취득자 분석 대시보드</div>
+            <div class="breadcrumb">홈 / 대시보드</div>
+        </div>
+        <div class="header-buttons">
+            <button>🔔</button>
+            <button>⚙️</button>
+        </div>
+    </div>
     """,
     unsafe_allow_html=True,
 )
@@ -55,6 +84,16 @@ CERT_DESC = {
     "통신기사": "통신 시스템 설계·운영",
     "소방설비기사": "소방 설비 설계·시공 전문가",
 }
+
+# 필터 상태 초기화
+for _k, _v in [
+    ("year_sel", []),
+    ("gender_sel", []),
+    ("region_sel", []),
+    ("cert_sel", []),
+    ("search_q", ""),
+]:
+    st.session_state.setdefault(_k, _v)
 
 @st.cache_data
 def generate_sample_data(n: int = 500) -> pd.DataFrame:
@@ -129,22 +168,54 @@ st.info("현재는 500건의 샘플 데이터만 표시됩니다. 72,000건 데�
 
 # 사이드바 필터
 st.sidebar.header("필터")
-year_sel = st.sidebar.multiselect("📅 연도", sorted(df["year"].unique()))
-gender_sel = st.sidebar.multiselect("🚻 성별", ALL_GENDERS)
-region_sel = st.sidebar.multiselect("📍 지역", ALL_REGIONS)
-cert_sel = st.sidebar.multiselect("📝 자격증 종류", ALL_CERTS)
-search_q = st.sidebar.text_input("텍스트 검색", placeholder="예: 서울 2020 여성")
+year_sel = st.sidebar.multiselect(
+    "📅 연도", sorted(df["year"].unique()), key="year_sel"
+)
+gender_sel = st.sidebar.multiselect("🚻 성별", ALL_GENDERS, key="gender_sel")
+region_sel = st.sidebar.multiselect("📍 지역", ALL_REGIONS, key="region_sel")
+cert_sel = st.sidebar.multiselect("📝 자격증 종류", ALL_CERTS, key="cert_sel")
+search_q = st.sidebar.text_input(
+    "텍스트 검색", placeholder="예: 서울 2020 여성", key="search_q"
+)
 parsed = parse_search(search_q)
 if parsed["year"]:
-    year_sel = parsed["year"]
+    st.session_state.year_sel = parsed["year"]
 if parsed["gender"]:
-    gender_sel = parsed["gender"]
+    st.session_state.gender_sel = parsed["gender"]
 if parsed["region"]:
-    region_sel = parsed["region"]
+    st.session_state.region_sel = parsed["region"]
 if parsed["certificate_type"]:
-    cert_sel = parsed["certificate_type"]
-if st.sidebar.button("모든 필터 초기화"):
-    st.experimental_rerun()
+    st.session_state.cert_sel = parsed["certificate_type"]
+
+col_reset, col_save, col_load = st.sidebar.columns(3)
+with col_reset:
+    if st.button("모두 선택 초기화", key="reset"):
+        for k in ["year_sel", "gender_sel", "region_sel", "cert_sel", "search_q"]:
+            st.session_state[k] = [] if k != "search_q" else ""
+        st.experimental_rerun()
+with col_save:
+    if st.button("저장", key="save"):
+        st.session_state.saved_filters = {
+            "year_sel": st.session_state.year_sel,
+            "gender_sel": st.session_state.gender_sel,
+            "region_sel": st.session_state.region_sel,
+            "cert_sel": st.session_state.cert_sel,
+            "search_q": st.session_state.search_q,
+        }
+        st.sidebar.success("저장되었습니다")
+with col_load:
+    if st.button("불러오기", key="load"):
+        saved = st.session_state.get("saved_filters")
+        if saved:
+            for k, v in saved.items():
+                st.session_state[k] = v
+            st.experimental_rerun()
+
+year_sel = st.session_state.year_sel
+gender_sel = st.session_state.gender_sel
+region_sel = st.session_state.region_sel
+cert_sel = st.session_state.cert_sel
+search_q = st.session_state.search_q
 
 filtered = df.copy()
 if year_sel:
@@ -163,13 +234,14 @@ _female = int(_gender_counts.get("여성", 0))
 _region_counts = filtered["region"].value_counts()
 _top_region = _region_counts.index[0] if not _region_counts.empty else "-"
 
-def metric_html(title: str, value: str, cls: str) -> str:
-    return f"<div class='metric-card {cls}'><h3>{title}</h3><p>{value}</p></div>"
+def metric_html(title: str, value: str, primary: bool = False) -> str:
+    cls = "metric-card primary" if primary else "metric-card"
+    return f"<div class='{cls}'><h3>{title}</h3><p>{value}</p></div>"
 
 m1, m2, m3 = st.columns(3)
-m1.markdown(metric_html("전체 취득자", f"{len(filtered):,}명", "metric-purple"), unsafe_allow_html=True)
-m2.markdown(metric_html("남 / 여 취득자", f"{_male:,} / {_female:,}", "metric-blue"), unsafe_allow_html=True)
-m3.markdown(metric_html("최다 지역", _top_region, "metric-indigo"), unsafe_allow_html=True)
+m1.markdown(metric_html("전체 취득자", f"{len(filtered):,}명", True), unsafe_allow_html=True)
+m2.markdown(metric_html("남 / 여 취득자", f"{_male:,} / {_female:,}"), unsafe_allow_html=True)
+m3.markdown(metric_html("최다 지역", _top_region), unsafe_allow_html=True)
 
 
 def add_download_button(fig, filename: str):
@@ -182,7 +254,16 @@ def add_download_button(fig, filename: str):
 # 연도별 자격증 취득자 수
 st.subheader("연도별 자격증 취득자 수")
 year_counts = filtered.groupby("year").size().reset_index(name="count")
-fig_year = px.line(year_counts, x="year", y="count", markers=True)
+fig_year = px.line(
+    year_counts,
+    x="year",
+    y="count",
+    markers=True,
+    color_discrete_sequence=["#2563eb"],
+)
+fig_year.update_traces(line=dict(width=2))
+fig_year.update_xaxes(showgrid=True, gridcolor="#e2e8f0", griddash="dot")
+fig_year.update_yaxes(showgrid=True, gridcolor="#e2e8f0", griddash="dot")
 st.plotly_chart(fig_year, use_container_width=True)
 if not year_counts.empty:
     max_row = year_counts.loc[year_counts["count"].idxmax()]
@@ -195,7 +276,12 @@ add_download_button(fig_year, "yearly_trend.png")
 st.subheader("성별 비율")
 gender_counts = _gender_counts.reset_index()
 gender_counts.columns = ["gender", "count"]
-fig_gender = px.pie(gender_counts, names="gender", values="count")
+fig_gender = px.pie(
+    gender_counts,
+    names="gender",
+    values="count",
+    color_discrete_sequence=["#2563eb", "#3b82f6"],
+)
 st.plotly_chart(fig_gender, use_container_width=True)
 if not gender_counts.empty:
     total = gender_counts["count"].sum()
@@ -208,7 +294,14 @@ add_download_button(fig_gender, "gender_ratio.png")
 st.subheader("지역별 분포")
 region_counts = _region_counts.reset_index()
 region_counts.columns = ["region", "count"]
-fig_region_bar = px.bar(region_counts, x="region", y="count")
+fig_region_bar = px.bar(
+    region_counts,
+    x="region",
+    y="count",
+    color_discrete_sequence=["#2563eb"],
+)
+fig_region_bar.update_xaxes(showgrid=True, gridcolor="#e2e8f0", griddash="dot")
+fig_region_bar.update_yaxes(showgrid=True, gridcolor="#e2e8f0", griddash="dot")
 st.plotly_chart(fig_region_bar, use_container_width=True)
 region_coords = {
     "서울": (37.5665, 126.9780),
@@ -264,7 +357,14 @@ def age_group(age: int) -> str:
 filtered["age_group"] = filtered["age"].apply(age_group)
 age_counts = filtered["age_group"].value_counts().reset_index()
 age_counts.columns = ["age_group", "count"]
-fig_age = px.bar(age_counts, x="age_group", y="count")
+fig_age = px.bar(
+    age_counts,
+    x="age_group",
+    y="count",
+    color_discrete_sequence=["#2563eb"],
+)
+fig_age.update_xaxes(showgrid=True, gridcolor="#e2e8f0", griddash="dot")
+fig_age.update_yaxes(showgrid=True, gridcolor="#e2e8f0", griddash="dot")
 st.plotly_chart(fig_age, use_container_width=True)
 if not age_counts.empty:
     top_age = age_counts.iloc[0]["age_group"]
@@ -287,7 +387,10 @@ fig_cert = px.bar(
     x="certificate_type",
     y="count",
     hover_data=["description"],
+    color_discrete_sequence=["#2563eb"],
 )
+fig_cert.update_xaxes(showgrid=True, gridcolor="#e2e8f0", griddash="dot")
+fig_cert.update_yaxes(showgrid=True, gridcolor="#e2e8f0", griddash="dot")
 st.plotly_chart(fig_cert, use_container_width=True)
 if not cert_counts.empty:
     top_cert = cert_counts.iloc[0]["certificate_type"]

--- a/dashboard.py
+++ b/dashboard.py
@@ -58,13 +58,17 @@ def generate_sample_data(n: int = 500) -> pd.DataFrame:
         )
     return pd.DataFrame(data)
 
-@st.cache_data
 def load_data(file: BytesIO | None = None) -> pd.DataFrame:
+    """엑셀을 불러오거나 샘플 데이터를 생성"""
     if file is not None:
-        return pd.read_excel(file)
-    if os.path.exists("certifications.xlsx"):
-        return pd.read_excel("certifications.xlsx")
-    return generate_sample_data(500)
+        df = pd.read_excel(file)
+    elif os.path.exists("certifications.xlsx"):
+        df = pd.read_excel("certifications.xlsx")
+    else:
+        df = generate_sample_data(500)
+    if "acquired_at" in df.columns:
+        df["acquired_at"] = pd.to_datetime(df["acquired_at"])
+    return df
 
 uploaded_file = st.sidebar.file_uploader("엑셀 데이터 업로드", type=["xlsx"])
 df = load_data(uploaded_file)

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,5 +1,4 @@
-# Required libraries:
-# streamlit, pandas, numpy, plotly, kaleido, openpyxl
+# Required libraries: streamlit, pandas, numpy, plotly, kaleido, openpyxl
 
 import os
 import streamlit as st

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,4 +1,4 @@
-# Required libraries: streamlit, pandas, numpy, plotly, kaleido, openpyxl
+# Required libraries: streamlit, pandas, numpy, plotly, kaleido
 
 import os
 import streamlit as st

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,225 @@
+# Required libraries:
+# streamlit, pandas, numpy, plotly, kaleido
+
+import streamlit as st
+import pandas as pd
+import numpy as np
+import plotly.express as px
+from datetime import datetime
+from io import BytesIO
+
+st.set_page_config(page_title="자격증 대시보드", layout="wide", page_icon="📊")
+
+@st.cache_data
+def load_data(n: int = 500):
+    np.random.seed(42)
+    years = np.arange(1993, 2026)
+    genders = ["남성", "여성"]
+    regions = [
+        "서울", "부산", "대구", "인천", "광주", "대전", "울산", "세종",
+        "경기", "강원", "충북", "충남", "전북", "전남", "경북", "경남", "제주"
+    ]
+    certificate_types = [
+        "정보처리기사", "전기기사", "건축기사", "토목기사", "기계기사",
+        "산업안전기사", "화공기사", "환경기사", "통신기사", "소방설비기사"
+    ]
+    cert_desc = {
+        "정보처리기사": "IT 시스템 개발 및 운영 능력 인증",
+        "전기기사": "전기 설계 및 시공 전문가",
+        "건축기사": "건축 설계·감리 기술자",
+        "토목기사": "토목 구조물 설계 및 관리",
+        "기계기사": "기계 설계·제작 능력 인증",
+        "산업안전기사": "산업현장 안전관리 전문가",
+        "화공기사": "화학공정 운영·관리 능력",
+        "환경기사": "환경오염 방지 기술자",
+        "통신기사": "통신 시스템 설계·운영",
+        "소방설비기사": "소방 설비 설계·시공 전문가",
+    }
+    data = []
+    for _ in range(n):
+        year = np.random.choice(years)
+        gender = np.random.choice(genders)
+        region = np.random.choice(regions)
+        age = np.random.randint(20, 61)
+        birth_year = year - age
+        cert = np.random.choice(certificate_types)
+        start = datetime(year, 1, 1)
+        day_offset = int(np.random.randint(0, 365))
+        acquired_at = start + pd.Timedelta(days=day_offset)
+        data.append(
+            {
+                "year": year,
+                "gender": gender,
+                "age": age,
+                "birth_year": birth_year,
+                "region": region,
+                "certificate_type": cert,
+                "acquired_at": acquired_at,
+            }
+        )
+    df = pd.DataFrame(data)
+    return df, cert_desc, regions, genders, certificate_types
+
+df, CERT_DESC, ALL_REGIONS, ALL_GENDERS, ALL_CERTS = load_data()
+
+
+def parse_search(query: str):
+    tokens = query.strip().split()
+    filters = {"year": [], "gender": [], "region": [], "certificate_type": []}
+    for tok in tokens:
+        if tok.isdigit():
+            y = int(tok)
+            if y in df["year"].unique():
+                filters["year"].append(y)
+        if tok in ALL_GENDERS:
+            filters["gender"].append(tok)
+        if tok in ALL_REGIONS:
+            filters["region"].append(tok)
+        if tok in ALL_CERTS:
+            filters["certificate_type"].append(tok)
+    return filters
+
+
+st.sidebar.header("필터")
+year_sel = st.sidebar.multiselect("연도", sorted(df["year"].unique()))
+gender_sel = st.sidebar.multiselect("성별", ALL_GENDERS)
+region_sel = st.sidebar.multiselect("지역", ALL_REGIONS)
+cert_sel = st.sidebar.multiselect("자격증 종류", ALL_CERTS)
+search_q = st.sidebar.text_input("텍스트 검색", placeholder="예: 서울 2020 여성")
+parsed = parse_search(search_q)
+if parsed["year"]:
+    year_sel = parsed["year"]
+if parsed["gender"]:
+    gender_sel = parsed["gender"]
+if parsed["region"]:
+    region_sel = parsed["region"]
+if parsed["certificate_type"]:
+    cert_sel = parsed["certificate_type"]
+
+filtered = df.copy()
+if year_sel:
+    filtered = filtered[filtered["year"].isin(year_sel)]
+if gender_sel:
+    filtered = filtered[filtered["gender"].isin(gender_sel)]
+if region_sel:
+    filtered = filtered[filtered["region"].isin(region_sel)]
+if cert_sel:
+    filtered = filtered[filtered["certificate_type"].isin(cert_sel)]
+
+
+def add_download_button(fig, filename: str):
+    buf = BytesIO()
+    fig.write_image(buf, format="png")
+    st.download_button("PNG로 다운로드", data=buf.getvalue(), file_name=filename, mime="image/png")
+
+
+# 연도별 자격증 취득자 수
+st.subheader("연도별 자격증 취득자 수")
+year_counts = filtered.groupby("year").size().reset_index(name="count")
+fig_year = px.line(year_counts, x="year", y="count", markers=True)
+st.plotly_chart(fig_year, use_container_width=True)
+if not year_counts.empty:
+    max_row = year_counts.loc[year_counts["count"].idxmax()]
+    st.caption(f"{int(max_row['year'])}년에 {int(max_row['count'])}명이 취득했습니다.")
+add_download_button(fig_year, "yearly_trend.png")
+
+# 성별 비율
+st.subheader("성별 비율")
+gender_counts = filtered["gender"].value_counts().reset_index()
+gender_counts.columns = ["gender", "count"]
+fig_gender = px.pie(gender_counts, names="gender", values="count")
+st.plotly_chart(fig_gender, use_container_width=True)
+if not gender_counts.empty:
+    total = gender_counts["count"].sum()
+    female = gender_counts.loc[gender_counts["gender"] == "여성", "count"]
+    female_pct = float(female) / total * 100 if not female.empty else 0
+    st.caption(f"여성 비율은 {female_pct:.1f}% 입니다.")
+add_download_button(fig_gender, "gender_ratio.png")
+
+# 지역별 분포
+st.subheader("지역별 분포")
+region_counts = filtered["region"].value_counts().reset_index()
+region_counts.columns = ["region", "count"]
+fig_region_bar = px.bar(region_counts, x="region", y="count")
+st.plotly_chart(fig_region_bar, use_container_width=True)
+region_coords = {
+    "서울": (37.5665, 126.9780),
+    "부산": (35.1796, 129.0756),
+    "대구": (35.8714, 128.6014),
+    "인천": (37.4563, 126.7052),
+    "광주": (35.1595, 126.8526),
+    "대전": (36.3504, 127.3845),
+    "울산": (35.5384, 129.3114),
+    "세종": (36.4800, 127.2890),
+    "경기": (37.2636, 127.0286),
+    "강원": (37.8228, 128.1555),
+    "충북": (36.6357, 127.4912),
+    "충남": (36.6588, 126.6728),
+    "전북": (35.8174, 127.1530),
+    "전남": (34.8161, 126.4630),
+    "경북": (36.4919, 128.8889),
+    "경남": (35.2383, 128.6917),
+    "제주": (33.4996, 126.5312),
+}
+region_geo = region_counts.copy()
+region_geo["lat"] = region_geo["region"].map(lambda r: region_coords[r][0])
+region_geo["lon"] = region_geo["region"].map(lambda r: region_coords[r][1])
+fig_geo = px.scatter_geo(
+    region_geo,
+    lat="lat",
+    lon="lon",
+    size="count",
+    color="count",
+    hover_name="region",
+    scope="asia",
+    color_continuous_scale="Blues",
+)
+fig_geo.update_geos(fitbounds="locations", visible=False)
+st.plotly_chart(fig_geo, use_container_width=True)
+if not region_counts.empty:
+    top_region = region_counts.iloc[0]["region"]
+    st.caption(f"가장 많은 취득 지역은 {top_region}입니다.")
+add_download_button(fig_region_bar, "region_bar.png")
+add_download_button(fig_geo, "region_map.png")
+
+# 연령대별 분포
+st.subheader("연령대별 분포")
+def age_group(age: int) -> str:
+    if age < 30:
+        return "20대"
+    elif age < 40:
+        return "30대"
+    else:
+        return "40대 이상"
+filtered["age_group"] = filtered["age"].apply(age_group)
+age_counts = filtered["age_group"].value_counts().reset_index()
+age_counts.columns = ["age_group", "count"]
+fig_age = px.bar(age_counts, x="age_group", y="count")
+st.plotly_chart(fig_age, use_container_width=True)
+if not age_counts.empty:
+    top_age = age_counts.iloc[0]["age_group"]
+    st.caption(f"가장 많은 연령대는 {top_age}입니다.")
+add_download_button(fig_age, "age_distribution.png")
+
+# 자격증 인기 순위
+st.subheader("자격증 인기 순위")
+if year_sel and len(year_sel) == 1:
+    cert_df = filtered[filtered["year"] == year_sel[0]]
+else:
+    cert_df = filtered
+cert_counts = (
+    cert_df["certificate_type"].value_counts().head(5).reset_index()
+)
+cert_counts.columns = ["certificate_type", "count"]
+cert_counts["description"] = cert_counts["certificate_type"].map(CERT_DESC)
+fig_cert = px.bar(
+    cert_counts,
+    x="certificate_type",
+    y="count",
+    hover_data=["description"],
+)
+st.plotly_chart(fig_cert, use_container_width=True)
+if not cert_counts.empty:
+    top_cert = cert_counts.iloc[0]["certificate_type"]
+    st.caption(f"가장 인기 있는 자격증은 {top_cert}입니다.")
+add_download_button(fig_cert, "top_certificates.png")

--- a/dashboard.py
+++ b/dashboard.py
@@ -10,6 +10,38 @@ from io import BytesIO
 
 st.set_page_config(page_title="자격증 대시보드", layout="wide", page_icon="📊")
 
+# ----- 스타일 및 헤더 구성 -----
+st.markdown(
+    """
+    <style>
+    .top-nav {
+        background: linear-gradient(90deg, #0d6efd, #2a52be);
+        color: white;
+        padding: 1rem 2rem;
+        border-radius: 8px;
+        font-size: 1.3rem;
+        font-weight: 700;
+        margin-bottom: 1rem;
+    }
+    .metric-card {
+        padding: 1.2rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        text-align: center;
+        color: white;
+    }
+    .metric-purple {background:#6f42c1;}
+    .metric-blue {background:#0d6efd;}
+    .metric-indigo {background:#6610f2;}
+    .metric-card h3{font-size:1rem;font-weight:600;margin:0 0 .5rem 0;}
+    .metric-card p{font-size:2rem;font-weight:700;margin:0;}
+    div[data-testid="stSidebar"] .stButton>button{width:100%;}
+    </style>
+    <div class="top-nav">자격증 취득자 분석 대시보드</div>
+    """,
+    unsafe_allow_html=True,
+)
+
 # 자격증 설명 사전
 CERT_DESC = {
     "정보처리기사": "IT 시스템 개발 및 운영 능력 인증",
@@ -92,24 +124,27 @@ def parse_search(query: str):
             filters["certificate_type"].append(tok)
     return filters
 
-st.title("자격증취득자 분석 대시보드")
+# 안내 문구
+st.info("현재는 500건의 샘플 데이터만 표시됩니다. 72,000건 데이터로 곧 업데이트될 예정입니다!")
 
-with st.expander("필터", expanded=True):
-    f1, f2, f3, f4 = st.columns(4)
-    year_sel = f1.multiselect("연도", sorted(df["year"].unique()))
-    gender_sel = f2.multiselect("성별", ALL_GENDERS)
-    region_sel = f3.multiselect("지역", ALL_REGIONS)
-    cert_sel = f4.multiselect("자격증 종류", ALL_CERTS)
-    search_q = st.text_input("텍스트 검색", placeholder="예: 서울 2020 여성")
-    parsed = parse_search(search_q)
-    if parsed["year"]:
-        year_sel = parsed["year"]
-    if parsed["gender"]:
-        gender_sel = parsed["gender"]
-    if parsed["region"]:
-        region_sel = parsed["region"]
-    if parsed["certificate_type"]:
-        cert_sel = parsed["certificate_type"]
+# 사이드바 필터
+st.sidebar.header("필터")
+year_sel = st.sidebar.multiselect("📅 연도", sorted(df["year"].unique()))
+gender_sel = st.sidebar.multiselect("🚻 성별", ALL_GENDERS)
+region_sel = st.sidebar.multiselect("📍 지역", ALL_REGIONS)
+cert_sel = st.sidebar.multiselect("📝 자격증 종류", ALL_CERTS)
+search_q = st.sidebar.text_input("텍스트 검색", placeholder="예: 서울 2020 여성")
+parsed = parse_search(search_q)
+if parsed["year"]:
+    year_sel = parsed["year"]
+if parsed["gender"]:
+    gender_sel = parsed["gender"]
+if parsed["region"]:
+    region_sel = parsed["region"]
+if parsed["certificate_type"]:
+    cert_sel = parsed["certificate_type"]
+if st.sidebar.button("모든 필터 초기화"):
+    st.experimental_rerun()
 
 filtered = df.copy()
 if year_sel:
@@ -128,10 +163,13 @@ _female = int(_gender_counts.get("여성", 0))
 _region_counts = filtered["region"].value_counts()
 _top_region = _region_counts.index[0] if not _region_counts.empty else "-"
 
+def metric_html(title: str, value: str, cls: str) -> str:
+    return f"<div class='metric-card {cls}'><h3>{title}</h3><p>{value}</p></div>"
+
 m1, m2, m3 = st.columns(3)
-m1.metric("전체 취득자", f"{len(filtered):,}명")
-m2.metric("남 / 여 취득자", f"{_male:,} / {_female:,}")
-m3.metric("최다 지역", _top_region)
+m1.markdown(metric_html("전체 취득자", f"{len(filtered):,}명", "metric-purple"), unsafe_allow_html=True)
+m2.markdown(metric_html("남 / 여 취득자", f"{_male:,} / {_female:,}", "metric-blue"), unsafe_allow_html=True)
+m3.markdown(metric_html("최다 지역", _top_region, "metric-indigo"), unsafe_allow_html=True)
 
 
 def add_download_button(fig, filename: str):

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,6 +1,7 @@
 # Required libraries:
-# streamlit, pandas, numpy, plotly, kaleido
+# streamlit, pandas, numpy, plotly, kaleido, openpyxl
 
+import os
 import streamlit as st
 import pandas as pd
 import numpy as np
@@ -10,31 +11,30 @@ from io import BytesIO
 
 st.set_page_config(page_title="자격증 대시보드", layout="wide", page_icon="📊")
 
+# 자격증 설명 사전
+CERT_DESC = {
+    "정보처리기사": "IT 시스템 개발 및 운영 능력 인증",
+    "전기기사": "전기 설계 및 시공 전문가",
+    "건축기사": "건축 설계·감리 기술자",
+    "토목기사": "토목 구조물 설계 및 관리",
+    "기계기사": "기계 설계·제작 능력 인증",
+    "산업안전기사": "산업현장 안전관리 전문가",
+    "화공기사": "화학공정 운영·관리 능력",
+    "환경기사": "환경오염 방지 기술자",
+    "통신기사": "통신 시스템 설계·운영",
+    "소방설비기사": "소방 설비 설계·시공 전문가",
+}
+
 @st.cache_data
-def load_data(n: int = 500):
+def generate_sample_data(n: int = 500) -> pd.DataFrame:
     np.random.seed(42)
     years = np.arange(1993, 2026)
     genders = ["남성", "여성"]
     regions = [
         "서울", "부산", "대구", "인천", "광주", "대전", "울산", "세종",
-        "경기", "강원", "충북", "충남", "전북", "전남", "경북", "경남", "제주"
+        "경기", "강원", "충북", "충남", "전북", "전남", "경북", "경남", "제주",
     ]
-    certificate_types = [
-        "정보처리기사", "전기기사", "건축기사", "토목기사", "기계기사",
-        "산업안전기사", "화공기사", "환경기사", "통신기사", "소방설비기사"
-    ]
-    cert_desc = {
-        "정보처리기사": "IT 시스템 개발 및 운영 능력 인증",
-        "전기기사": "전기 설계 및 시공 전문가",
-        "건축기사": "건축 설계·감리 기술자",
-        "토목기사": "토목 구조물 설계 및 관리",
-        "기계기사": "기계 설계·제작 능력 인증",
-        "산업안전기사": "산업현장 안전관리 전문가",
-        "화공기사": "화학공정 운영·관리 능력",
-        "환경기사": "환경오염 방지 기술자",
-        "통신기사": "통신 시스템 설계·운영",
-        "소방설비기사": "소방 설비 설계·시공 전문가",
-    }
+    certificate_types = list(CERT_DESC.keys())
     data = []
     for _ in range(n):
         year = np.random.choice(years)
@@ -57,20 +57,30 @@ def load_data(n: int = 500):
                 "acquired_at": acquired_at,
             }
         )
-    df = pd.DataFrame(data)
-    return df, cert_desc, regions, genders, certificate_types
+    return pd.DataFrame(data)
 
-df, CERT_DESC, ALL_REGIONS, ALL_GENDERS, ALL_CERTS = load_data()
+@st.cache_data
+def load_data(file: BytesIO | None = None) -> pd.DataFrame:
+    if file is not None:
+        return pd.read_excel(file)
+    if os.path.exists("certifications.xlsx"):
+        return pd.read_excel("certifications.xlsx")
+    return generate_sample_data(500)
+
+uploaded_file = st.sidebar.file_uploader("엑셀 데이터 업로드", type=["xlsx"])
+df = load_data(uploaded_file)
+
+ALL_REGIONS = sorted(df["region"].unique())
+ALL_GENDERS = sorted(df["gender"].unique())
+ALL_CERTS = sorted(df["certificate_type"].unique())
 
 
 def parse_search(query: str):
     tokens = query.strip().split()
     filters = {"year": [], "gender": [], "region": [], "certificate_type": []}
     for tok in tokens:
-        if tok.isdigit():
-            y = int(tok)
-            if y in df["year"].unique():
-                filters["year"].append(y)
+        if tok.isdigit() and int(tok) in df["year"].unique():
+            filters["year"].append(int(tok))
         if tok in ALL_GENDERS:
             filters["gender"].append(tok)
         if tok in ALL_REGIONS:
@@ -79,22 +89,24 @@ def parse_search(query: str):
             filters["certificate_type"].append(tok)
     return filters
 
+st.title("자격증취득자 분석 대시보드")
 
-st.sidebar.header("필터")
-year_sel = st.sidebar.multiselect("연도", sorted(df["year"].unique()))
-gender_sel = st.sidebar.multiselect("성별", ALL_GENDERS)
-region_sel = st.sidebar.multiselect("지역", ALL_REGIONS)
-cert_sel = st.sidebar.multiselect("자격증 종류", ALL_CERTS)
-search_q = st.sidebar.text_input("텍스트 검색", placeholder="예: 서울 2020 여성")
-parsed = parse_search(search_q)
-if parsed["year"]:
-    year_sel = parsed["year"]
-if parsed["gender"]:
-    gender_sel = parsed["gender"]
-if parsed["region"]:
-    region_sel = parsed["region"]
-if parsed["certificate_type"]:
-    cert_sel = parsed["certificate_type"]
+with st.expander("필터", expanded=True):
+    f1, f2, f3, f4 = st.columns(4)
+    year_sel = f1.multiselect("연도", sorted(df["year"].unique()))
+    gender_sel = f2.multiselect("성별", ALL_GENDERS)
+    region_sel = f3.multiselect("지역", ALL_REGIONS)
+    cert_sel = f4.multiselect("자격증 종류", ALL_CERTS)
+    search_q = st.text_input("텍스트 검색", placeholder="예: 서울 2020 여성")
+    parsed = parse_search(search_q)
+    if parsed["year"]:
+        year_sel = parsed["year"]
+    if parsed["gender"]:
+        gender_sel = parsed["gender"]
+    if parsed["region"]:
+        region_sel = parsed["region"]
+    if parsed["certificate_type"]:
+        cert_sel = parsed["certificate_type"]
 
 filtered = df.copy()
 if year_sel:
@@ -106,12 +118,25 @@ if region_sel:
 if cert_sel:
     filtered = filtered[filtered["certificate_type"].isin(cert_sel)]
 
+# 상단 주요 지표
+_gender_counts = filtered["gender"].value_counts()
+_male = int(_gender_counts.get("남성", 0))
+_female = int(_gender_counts.get("여성", 0))
+_region_counts = filtered["region"].value_counts()
+_top_region = _region_counts.index[0] if not _region_counts.empty else "-"
+
+m1, m2, m3 = st.columns(3)
+m1.metric("전체 취득자", f"{len(filtered):,}명")
+m2.metric("남 / 여 취득자", f"{_male:,} / {_female:,}")
+m3.metric("최다 지역", _top_region)
+
 
 def add_download_button(fig, filename: str):
     buf = BytesIO()
     fig.write_image(buf, format="png")
-    st.download_button("PNG로 다운로드", data=buf.getvalue(), file_name=filename, mime="image/png")
-
+    st.download_button(
+        "PNG로 다운로드", data=buf.getvalue(), file_name=filename, mime="image/png"
+    )
 
 # 연도별 자격증 취득자 수
 st.subheader("연도별 자격증 취득자 수")
@@ -120,12 +145,14 @@ fig_year = px.line(year_counts, x="year", y="count", markers=True)
 st.plotly_chart(fig_year, use_container_width=True)
 if not year_counts.empty:
     max_row = year_counts.loc[year_counts["count"].idxmax()]
-    st.caption(f"{int(max_row['year'])}년에 {int(max_row['count'])}명이 취득했습니다.")
+    st.caption(
+        f"{int(max_row['year'])}년에 {int(max_row['count'])}명이 취득했습니다."
+    )
 add_download_button(fig_year, "yearly_trend.png")
 
 # 성별 비율
 st.subheader("성별 비율")
-gender_counts = filtered["gender"].value_counts().reset_index()
+gender_counts = _gender_counts.reset_index()
 gender_counts.columns = ["gender", "count"]
 fig_gender = px.pie(gender_counts, names="gender", values="count")
 st.plotly_chart(fig_gender, use_container_width=True)
@@ -138,7 +165,7 @@ add_download_button(fig_gender, "gender_ratio.png")
 
 # 지역별 분포
 st.subheader("지역별 분포")
-region_counts = filtered["region"].value_counts().reset_index()
+region_counts = _region_counts.reset_index()
 region_counts.columns = ["region", "count"]
 fig_region_bar = px.bar(region_counts, x="region", y="count")
 st.plotly_chart(fig_region_bar, use_container_width=True)
@@ -184,6 +211,7 @@ add_download_button(fig_geo, "region_map.png")
 
 # 연령대별 분포
 st.subheader("연령대별 분포")
+
 def age_group(age: int) -> str:
     if age < 30:
         return "20대"
@@ -191,6 +219,7 @@ def age_group(age: int) -> str:
         return "30대"
     else:
         return "40대 이상"
+
 filtered["age_group"] = filtered["age"].apply(age_group)
 age_counts = filtered["age_group"].value_counts().reset_index()
 age_counts.columns = ["age_group", "count"]
@@ -207,11 +236,11 @@ if year_sel and len(year_sel) == 1:
     cert_df = filtered[filtered["year"] == year_sel[0]]
 else:
     cert_df = filtered
-cert_counts = (
-    cert_df["certificate_type"].value_counts().head(5).reset_index()
-)
+cert_counts = cert_df["certificate_type"].value_counts().head(5).reset_index()
 cert_counts.columns = ["certificate_type", "count"]
-cert_counts["description"] = cert_counts["certificate_type"].map(CERT_DESC)
+cert_counts["description"] = cert_counts["certificate_type"].map(
+    lambda x: CERT_DESC.get(x, "설명 없음")
+)
 fig_cert = px.bar(
     cert_counts,
     x="certificate_type",
@@ -223,3 +252,4 @@ if not cert_counts.empty:
     top_cert = cert_counts.iloc[0]["certificate_type"]
     st.caption(f"가장 인기 있는 자격증은 {top_cert}입니다.")
 add_download_button(fig_cert, "top_certificates.png")
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>자격증 취득자 대시보드</title>
+  <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+    .container { display: flex; flex-direction: column; padding: 10px; gap: 10px; }
+    .filters { display: flex; flex-wrap: wrap; gap: 10px; }
+    .charts { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 20px; }
+    .chart { border: 1px solid #ccc; padding: 10px; }
+    button.download { margin-top: 5px; }
+    @media (max-width: 600px) { .filters { flex-direction: column; } }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>자격증 취득자 대시보드</h1>
+  <div class="filters">
+    <select id="yearFilter"><option value="all">연도 전체</option></select>
+    <select id="genderFilter">
+      <option value="all">성별 전체</option>
+      <option value="남성">남성</option>
+      <option value="여성">여성</option>
+    </select>
+    <select id="regionFilter"><option value="all">지역 전체</option></select>
+    <select id="certificateFilter"><option value="all">자격증 전체</option></select>
+    <input type="text" id="searchBox" placeholder="예: 서울 2020 여성" />
+    <button id="searchBtn">검색</button>
+  </div>
+  <div id="summary"></div>
+  <div class="charts">
+    <div class="chart"><div id="yearChart"></div><button class="download" data-chart="yearChart">PNG 다운로드</button></div>
+    <div class="chart"><div id="genderChart"></div><button class="download" data-chart="genderChart">PNG 다운로드</button></div>
+    <div class="chart"><div id="regionBarChart"></div><button class="download" data-chart="regionBarChart">PNG 다운로드</button></div>
+    <div class="chart"><div id="regionMap"></div><button class="download" data-chart="regionMap">PNG 다운로드</button></div>
+    <div class="chart"><div id="ageChart"></div><button class="download" data-chart="ageChart">PNG 다운로드</button></div>
+    <div class="chart"><div id="certificateChart"></div><button class="download" data-chart="certificateChart">PNG 다운로드</button></div>
+  </div>
+</div>
+<script>
+const years = Array.from({length: 2025-1993+1}, (_,i)=>1993+i);
+const genders = ['남성','여성'];
+const regions = ['서울','부산','대구','인천','광주','대전','울산','세종','경기','강원','충북','충남','전북','전남','경북','경남','제주'];
+const certificateTypes = ['정보처리기사','전기기사','토목기사','산업안전기사','조경기사','건축기사'];
+const certDescriptions = {
+  '정보처리기사':'소프트웨어 개발과 운영에 대한 자격',
+  '전기기사':'전기설비의 설계 및 관리',
+  '토목기사':'토목 구조물의 설계 및 시공',
+  '산업안전기사':'산업현장의 안전 관리 전문가',
+  '조경기사':'조경 설계와 시공 전문가',
+  '건축기사':'건축물 설계와 시공 관리'
+};
+const regionCoords = {
+  '서울':[37.5665,126.9780], '부산':[35.1796,129.0756], '대구':[35.8714,128.6014], '인천':[37.4563,126.7052],
+  '광주':[35.1595,126.8526], '대전':[36.3504,127.3845], '울산':[35.5384,129.3114], '세종':[36.4800,127.2890],
+  '경기':[37.4138,127.5183], '강원':[37.8228,128.1555], '충북':[36.8000,127.7000], '충남':[36.5184,126.8000],
+  '전북':[35.7175,127.1530], '전남':[34.8679,126.9910], '경북':[36.5760,128.5056], '경남':[35.4606,128.2132], '제주':[33.4996,126.5312]
+};
+function rand(arr){ return arr[Math.floor(Math.random()*arr.length)]; }
+function randomDate(year){
+  const m = String(Math.floor(Math.random()*12)+1).padStart(2,'0');
+  const d = String(Math.floor(Math.random()*28)+1).padStart(2,'0');
+  return `${year}-${m}-${d}`;
+}
+const data = Array.from({length:500}, ()=>{
+  const year = rand(years);
+  const birthYear = year - (20 + Math.floor(Math.random()*25));
+  const age = year - birthYear;
+  return {
+    year: year,
+    gender: rand(genders),
+    age: age,
+    birth_year: birthYear,
+    region: rand(regions),
+    certificate_type: rand(certificateTypes),
+    acquired_at: randomDate(year)
+  };
+});
+const currentFilters = {year:'all', gender:'all', region:'all', certificate:'all'};
+function populateFilters(){
+  const yf = document.getElementById('yearFilter');
+  years.forEach(y=>{const o=document.createElement('option');o.value=y;o.textContent=y;yf.appendChild(o);});
+  const rf=document.getElementById('regionFilter');
+  regions.forEach(r=>{const o=document.createElement('option');o.value=r;o.textContent=r;rf.appendChild(o);});
+  const cf=document.getElementById('certificateFilter');
+  certificateTypes.forEach(c=>{const o=document.createElement('option');o.value=c;o.textContent=c;cf.appendChild(o);});
+}
+function getFiltered(){
+  return data.filter(d =>
+    (currentFilters.year==='all'||d.year==currentFilters.year) &&
+    (currentFilters.gender==='all'||d.gender===currentFilters.gender) &&
+    (currentFilters.region==='all'||d.region===currentFilters.region) &&
+    (currentFilters.certificate==='all'||d.certificate_type===currentFilters.certificate)
+  );
+}
+function drawYearChart(filtered){
+  const counts={}; filtered.forEach(d=>{counts[d.year]=(counts[d.year]||0)+1;});
+  const xs=Object.keys(counts).sort(); const ys=xs.map(x=>counts[x]);
+  Plotly.newPlot('yearChart',[{x:xs,y:ys,mode:'lines+markers'}],{title:'연도별 자격증 취득자 수'});
+}
+function drawGenderChart(filtered){
+  const counts=genders.map(g=>filtered.filter(d=>d.gender===g).length);
+  Plotly.newPlot('genderChart',[{labels:genders,values:counts,type:'pie'}],{title:'성별 비율'});
+}
+function drawRegionBar(filtered){
+  const counts=regions.map(r=>filtered.filter(d=>d.region===r).length);
+  Plotly.newPlot('regionBarChart',[{x:regions,y:counts,type:'bar'}],{title:'지역별 분포'});
+}
+function drawRegionMap(filtered){
+  const counts={}; filtered.forEach(d=>{counts[d.region]=(counts[d.region]||0)+1;});
+  const lats=[],lons=[],texts=[],sizes=[]; Object.keys(regionCoords).forEach(r=>{
+    lats.push(regionCoords[r][0]); lons.push(regionCoords[r][1]);
+    const c=counts[r]||0; texts.push(`${r}: ${c}`); sizes.push(5+c);
+  });
+  Plotly.newPlot('regionMap',[{
+    type:'scattergeo', lat:lats, lon:lons, text:texts,
+    marker:{size:sizes,color:sizes,colorscale:'Blues',reversescale:true,showscale:true}
+  }],{title:'지도 기반 지역 분포', geo:{scope:'asia',center:{lat:36.5,lon:127.8},projection:{type:'mercator'}}});
+}
+function drawAgeChart(filtered){
+  const groups={'20대':0,'30대':0,'40대 이상':0};
+  filtered.forEach(d=>{ if(d.age<30) groups['20대']++; else if(d.age<40) groups['30대']++; else groups['40대 이상']++; });
+  Plotly.newPlot('ageChart',[{x:Object.keys(groups),y:Object.values(groups),type:'bar'}],{title:'연령대별 분포'});
+}
+function drawCertificateChart(filtered){
+  const counts={}; filtered.forEach(d=>{counts[d.certificate_type]=(counts[d.certificate_type]||0)+1;});
+  const entries=Object.entries(counts).sort((a,b)=>b[1]-a[1]).slice(0,5);
+  const x=entries.map(e=>e[0]); const y=entries.map(e=>e[1]);
+  const text=x.map(c=>certDescriptions[c]);
+  Plotly.newPlot('certificateChart',[{x:x,y:y,type:'bar',text:text,hovertemplate:'%{x}<br>%{y}명<br>%{text}<extra></extra>'}],{title:'자격증 인기 순위'});
+}
+function updateSummary(filtered){
+  const total=filtered.length;
+  const yearText=currentFilters.year==='all'?'전체 기간':currentFilters.year+'년';
+  const female=filtered.filter(d=>d.gender==='여성').length;
+  const ratio=total? (female/total*100).toFixed(1):0;
+  document.getElementById('summary').textContent=`${yearText} 여성 취득자 비율은 ${ratio}%입니다.`;
+}
+function updateCharts(){
+  const filtered=getFiltered();
+  drawYearChart(filtered); drawGenderChart(filtered); drawRegionBar(filtered);
+  drawRegionMap(filtered); drawAgeChart(filtered); drawCertificateChart(filtered); updateSummary(filtered);
+}
+function updateFilterControls(){
+  document.getElementById('yearFilter').value=currentFilters.year;
+  document.getElementById('genderFilter').value=currentFilters.gender;
+  document.getElementById('regionFilter').value=currentFilters.region;
+  document.getElementById('certificateFilter').value=currentFilters.certificate;
+}
+function parseSearch(){
+  const tokens=document.getElementById('searchBox').value.trim().split(/\s+/);
+  tokens.forEach(tok=>{
+    if(years.includes(parseInt(tok))) currentFilters.year=parseInt(tok);
+    else if(genders.includes(tok)) currentFilters.gender=tok;
+    else if(regions.includes(tok)) currentFilters.region=tok;
+    else if(certificateTypes.includes(tok)) currentFilters.certificate=tok;
+  });
+  updateFilterControls(); updateCharts();
+}
+populateFilters();
+updateCharts();
+document.getElementById('yearFilter').addEventListener('change',e=>{currentFilters.year=e.target.value==='all'?'all':parseInt(e.target.value);updateCharts();});
+document.getElementById('genderFilter').addEventListener('change',e=>{currentFilters.gender=e.target.value;updateCharts();});
+document.getElementById('regionFilter').addEventListener('change',e=>{currentFilters.region=e.target.value;updateCharts();});
+document.getElementById('certificateFilter').addEventListener('change',e=>{currentFilters.certificate=e.target.value;updateCharts();});
+
+document.getElementById('searchBtn').addEventListener('click',parseSearch);
+document.getElementById('searchBox').addEventListener('keypress',e=>{if(e.key==='Enter') parseSearch();});
+
+document.querySelectorAll('button.download').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    const chartId=btn.getAttribute('data-chart');
+    Plotly.downloadImage(chartId,{format:'png',filename:chartId});
+  });
+});
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+streamlit
+pandas
+numpy
+plotly
+kaleido
+openpyxl


### PR DESCRIPTION
## Summary
- build standalone web dashboard `index.html` with filters, charts, and search
- generate 500-row random dataset and show yearly trends, gender ratio, regional map/bar, age groups, and top certificates with tooltips
- add PNG download buttons and automatic summary text

## Testing
- `python -m py_compile dashboard.py`
- `python -m http.server 8000 >/tmp/server.log 2>&1 &`
- `sleep 1`
- `curl -I http://localhost:8000/index.html`
- `kill 4111`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d295598832f98d1aa13b9d4388c